### PR TITLE
Move navbar out of flex container to fix iOS rendering

### DIFF
--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -17,13 +17,15 @@
 
 </head>
 
-<body class="d-flex flex-column vh-100">
+<body>
     <%- include('../partials/navbar')%>
-    <main class="container mt-5">
-        <%- include('../partials/flash')%>
-        <%- body %>
-    </main>
-    <%- include('../partials/footer')%>
+    <div class="d-flex flex-column vh-100">
+        <main class="container mt-5">
+            <%- include('../partials/flash')%>
+            <%- body %>
+        </main>
+        <%- include('../partials/footer')%>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
         crossorigin="anonymous"></script>


### PR DESCRIPTION
The navbar does not render correctly on iOS - it does not force content below down when expanded. Having tried everything else with no improvement, creating an extra div inside the body so the navbar can sit outside the flexbox container appears to have fixed the issue with no unintended consequences I have found so far!

By the way, I have just finished WDB which was awesome - took over my life for a couple of weeks! I'm a Github rookie too so apologies if I'm going about anything the wrong way. My first big problem post-deployment of my YelpCamp was the security policy not allowing the maps to render on iOS. I found the fix by seeing somebody had proposed a change on here so thought I'd try and use this as a mechanism to share my navbar woes with the community - it's a surprisingly not well-documented matter on the likes of stack-exchange...