### PR TITLE
delete cloudindary images for delete route

### DIFF
--- a/controllers/campgrounds.js
+++ b/controllers/campgrounds.js
@@ -72,6 +72,10 @@ module.exports.updateCampground = async (req, res) => {
 
 module.exports.deleteCampground = async (req, res) => {
     const { id } = req.params;
+    const campground = await Campground.findById(id);
+    campground.images.map((image) => {
+        cloudinary.uploader.destroy(image.filename);
+    });
     await Campground.findByIdAndDelete(id);
     req.flash('success', 'Successfully deleted campground')
     res.redirect('/campgrounds');


### PR DESCRIPTION
Added some code that will delete images in cloudinary from the delete route. Technically, the code is in the campground controller, but it's the deleteCampground route that will initiate the action. Makes delete the same as the editCampground controller.

Minor inconvenience of having the cloudinary account get filled, though the campgrounds were deleted. Thinking about making the code shorter, but a friend at Salesforce said his department policy is "NO one line functions." Not even their smartest engineers remember what they did six months later. Better to write it out and make it easy to understand.