### PR TITLE
Fix styling for bootstrap 5.0.x

### DIFF
--- a/views/home.ejs
+++ b/views/home.ejs
@@ -14,8 +14,8 @@
     <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
         <header class="mb-auto">
             <div>
-                <h3 class="float-md-left mb-0">YelpCamp</h3>
-                <nav class="nav nav-masthead justify-content-center float-md-right">
+                <h3 class="float-md-start mb-0">YelpCamp</h3>
+                <nav class="nav nav-masthead justify-content-center float-md-end">
                     <a class="nav-link active" aria-current="page" href="#">Home</a>
                     <a class="nav-link" href="/campgrounds">Campgrounds</a>
                     <% if(!currentUser) { %>


### PR DESCRIPTION
Currently styling is broken, navigation all navigation elements are centered.
In the latest branch of bootstrap float-*-left/float-*-right are obsolete and renamed to float-*-start/float-*-end.