### PR TITLE
Update app.js | required for bootstrap 5.2 version |  

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,6 +89,7 @@ const scriptSrcUrls = [
 ];
 const styleSrcUrls = [
     "https://kit-free.fontawesome.com",
+    "https://cdn.jsdelivr.net/",
     "https://stackpath.bootstrapcdn.com",
     "https://api.mapbox.com",
     "https://api.tiles.mapbox.com",


### PR DESCRIPTION
new cdn link added to styleScrUrls |  otherwise shows error for bootstrap 5.2version